### PR TITLE
cmd/httprequest-generate-client: use correct package

### DIFF
--- a/cmd/httprequest-generate-client/main.go
+++ b/cmd/httprequest-generate-client/main.go
@@ -16,6 +16,7 @@ import (
 	"text/template"
 
 	"go/types"
+
 	"golang.org/x/tools/go/loader"
 	"gopkg.in/errgo.v1"
 )
@@ -165,9 +166,9 @@ func serverMethods(serverPkg, serverType, localPkg string) ([]method, []string, 
 	ptrObjType := types.NewPointer(objTypeName.Type())
 
 	imports := map[string]string{
-		"github.com/juju/httprequest": "httprequest",
-		"golang.org/x/net/context":    "context",
-		localPkg:                      "",
+		"gopkg.in/httprequest.v1":  "httprequest",
+		"golang.org/x/net/context": "context",
+		localPkg:                   "",
 	}
 	var methods []method
 	mset := types.NewMethodSet(ptrObjType)


### PR DESCRIPTION
The package is now `gopkg.in/httprequest.v1`.