### PR TITLE
create requests with GetBody set.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 go_import_path: "gopkg.in/httprequest.v1"
 go: 
-  - "1.11"
+  - "1.11.x"
 script: GO111MODULE=on go test ./...

--- a/client_test.go
+++ b/client_test.go
@@ -71,9 +71,11 @@ var callTests = []struct {
 	req:         &chM3Req{},
 	expectError: `Get http://.*/m3: unexpected HTTP response status: 500 Internal Server Error`,
 }, {
-	about:       "unexpected redirect",
-	req:         &chM2RedirectM2Req{},
-	expectError: `Post http://.*/m2/foo//: unexpected redirect \(status 307 Temporary Redirect\) from "http://.*/m2/foo//" to "http://.*/m2/foo"`,
+	about: "unexpected redirect",
+	req: &chM2RedirectM2Req{
+		Body: struct{ I int }{999},
+	},
+	expectResp: &chM2Resp{"foo", 999},
 }, {
 	about:       "bad content in successful response",
 	req:         &chM4Req{},
@@ -236,7 +238,7 @@ var doTests = []struct {
 	client: httprequest.Client{
 		BaseURL: ":::",
 	},
-	expectError: `cannot parse ":::": parse :::: missing protocol scheme`,
+	expectError: `cannot parse ":::": parse "?:::"?: missing protocol scheme`,
 }, {
 	about: "Do returns error",
 	client: httprequest.Client{
@@ -705,6 +707,9 @@ type chInvalidM2Req struct {
 
 type chM2RedirectM2Req struct {
 	httprequest.Route `httprequest:"POST /m2/foo//"`
+	Body              struct {
+		I int
+	} `httprequest:",body"`
 }
 
 type chM2Resp struct {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -358,7 +358,7 @@ var marshalTests = []struct {
 	}{
 		F1: "test",
 	},
-	expectError: `parse %%: invalid URL escape \"%%\"`,
+	expectError: `parse \"?%%\"?: invalid URL escape \"%%\"`,
 }, {
 	about:     "value cannot be marshaled to json",
 	urlString: "http://localhost",

--- a/type.go
+++ b/type.go
@@ -89,7 +89,7 @@ type field struct {
 	unmarshal unmarshaler
 
 	// marshal is used to marshal the value into the
-	// give filed. The value passed as its first argument is not
+	// given field. The value passed as its first argument is not
 	// a pointer type, but it is addressable.
 	marshal marshaler
 


### PR DESCRIPTION
GetBody is used by the http client library to retry in the event of an
unexpected redirect, or to recover in some HTTP 2 failure cases.