### PR TITLE
Travis-ci: added support for ppc64le & update go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
+arch:
+  - AMD64
+  - ppc64le
 go_import_path: "gopkg.in/httprequest.v1"
 go: 
-  - "1.11.x"
+  - "1.14.x"
+  - "1.15.x"
 script: GO111MODULE=on go test ./...


### PR DESCRIPTION
Signed-off-by: Devendranath Thadi <devendranath.thadi3@gmail.com>

Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.